### PR TITLE
Small tweaks to your PR, script dynamically loads tags instead of hardcoding values, and edge cases are handled

### DIFF
--- a/kubejs/server_scripts/recipes/insolator.js
+++ b/kubejs/server_scripts/recipes/insolator.js
@@ -1,55 +1,23 @@
-const flowers = [
-  "minecraft:pitcher_plant",
-  "minecraft:torchflower",
-  "minecraft:flowering_azalea_leaves",
-  "minecraft:cherry_leaves",
-  "minecraft:pink_petals",
-  "biomesoplenty:flowering_oak_leaves",
-  "biomesoplenty:jacaranda_leaves",
-  "biomesoplenty:snowblossom_leaves",
-  "biomesoplenty:white_petals",
-  "biomesoplenty:wildflower",
-  "biomesoplenty:rose",
-  "biomesoplenty:violet",
-  "biomesoplenty:lavender",
-  "biomesoplenty:white_lavender",
-  "biomesoplenty:pink_daffodil",
-  "biomesoplenty:pink_hibiscus",
-  "biomesoplenty:wilted_lily",
-  "biomesoplenty:glowflower",
-  "biomesoplenty:burning_blossom",
-  "biomesoplenty:endbloom",
-  "biomesoplenty:orange_cosmos",
-  "biomesoplenty:tall_lavender",
-  "biomesoplenty:tall_white_lavender",
-  "biomesoplenty:blue_hydrangea",
-  "biomesoplenty:goldenrod",
-  "biomesoplenty:icy_iris",
-  "farmersdelight:wild_carrots",
-  "farmersdelight:wild_potatoes",
-  "farmersdelight:wild_rice",
-  "farmersdelight:wild_carrots",
-  "farmersdelight:wild_beetroots",
-  "farmersdelight:wild_cabbages",
-  "farmersdelight:wild_tomatoes",
-  "farmersdelight:wild_onions",
-  "supplementaries:wild_flax"
-];
-
 ServerEvents.recipes(event => {
-  flowers.forEach(flower => {
-    event.custom({
-      "type": "thermal:insolator",
-      "ingredient": {
-        "item": flower
-      },
-      "result": [
-        {
-          "item": flower,
-          "chance": 2
+    // Remove existing insolator flower recipes since we're adding them back anyways
+    event.remove({ type: "thermal:insolator", input: "#minecraft:flowers", not:{ input:"#minecraft:saplings" } })
+
+    Ingredient.of("#minecraft:flowers").itemIds.forEach(flower => {
+        // Automatically adds all flowers as thermal insolator recipes. We're blacklisting special cases like leaves and saplings which are occasionally tagged as flowers for some reason
+        if( !( Ingredient.of("#minecraft:saplings").test(flower) || Ingredient.of("#minecraft:leaves").test(flower) ) ) {
+            event.custom({
+                "type": "thermal:insolator",
+                "ingredient": {
+                    "item": flower
+                },
+                "result": [
+                    {
+                    "item": flower,
+                    "chance": 2
+                    }
+                ],
+                "experience": 0
+            })
         }
-      ],
-      "experience": 0
-    });
-  });
-});
+    })
+})

--- a/kubejs/server_scripts/tags.js
+++ b/kubejs/server_scripts/tags.js
@@ -205,6 +205,9 @@ ServerEvents.tags("item", event => {
 
     // This tag auto adds the beacon_payment_items tag which we don't want
     event.remove("create:create_ingots", "create:andesite_alloy")
+
+    // This had the #minecraft:flowers block tag but not the item tag??? Fixing for support with the thermal insolator flowers script
+    event.add("minecraft:flowers", "biomesoplenty:waterlily")
 })
 
 ServerEvents.tags("block", event => {


### PR DESCRIPTION
this should allow for better mod compatibly in the event CABIN or an individual user adds a new mod with new flowers. avoids creating recipes for items that are tagged as leaves or saplings and it also removes the original insolator flower recipes to avoid having duplicate recipes. Also added the #minecraft:flowers item tag to the waterlily from biomes o plenty because it didn't have it for some reason.

once you merge these changes into your fork they should auto apply to your pull request on the main repo i'm pretty sure